### PR TITLE
Hide Times All Styles, Hide Leaderboard Medals

### DIFF
--- a/Modules/Misc/CommunityMedals.cs
+++ b/Modules/Misc/CommunityMedals.cs
@@ -467,21 +467,15 @@ namespace NeonLite.Modules
                 else
                     __instance.devStamp.SetActive(false);
 
-                if(hideOld.Value)
+                if (hideOld.Value)
                 {
                     String hiddenTime = "?:??.???";
-                    if(medalEarned < I(MedalEnum.Sapphire))
-                        __instance._aceMedalTime.text = (string)styleTime.Invoke(__instance, [
-                            hiddenTime,
-                            false]);
+                    if (medalEarned < I(MedalEnum.Sapphire))
+                        __instance._aceMedalTime.text = hiddenTime;
                     if (medalEarned < I(MedalEnum.Amethyst))
-                        __instance._goldMedalTime.text = (string)styleTime.Invoke(__instance, [
-                            hiddenTime,
-                            false]);
+                        __instance._goldMedalTime.text = hiddenTime;
                     if (medalEarned < I(MedalEnum.Emerald))
-                        __instance._silverMedalTime.text = (string)styleTime.Invoke(__instance, [
-                            hiddenTime,
-                            false]);
+                        __instance._silverMedalTime.text = hiddenTime;
                 }
             }
         }
@@ -545,11 +539,11 @@ namespace NeonLite.Modules
             int medalEarned = GetMedalIndex(levelData.levelID, newData._scoreValueMilliseconds * 1000);
             AdjustMaterial(__instance._medal);
 
-            if(hideLeaderboard.Value && medalEarned >= (int)MedalEnum.Dev)
+            if (hideLeaderboard.Value && medalEarned >= I(MedalEnum.Dev))
             {
                 int userMedal = GetMedalIndex(levelData.levelID); // medal the user has on this level
                 if (medalEarned > userMedal)
-                    medalEarned = Math.Max(userMedal, (int)MedalEnum.Ace); // ensure the medal to be displayed is only as high as the user's, but only as low as ace
+                    medalEarned = Math.Max(userMedal, I(MedalEnum.Ace)); // ensure the medal to be displayed is only as high as the user's, but only as low as ace
             }
 
             if (!levelData.isSidequest)

--- a/Modules/Misc/CommunityMedals.cs
+++ b/Modules/Misc/CommunityMedals.cs
@@ -84,6 +84,7 @@ namespace NeonLite.Modules
         public static MelonPreferences_Entry<bool> setting;
         internal static MelonPreferences_Entry<bool> oldStyle;
         internal static MelonPreferences_Entry<bool> hideOld;
+        internal static MelonPreferences_Entry<bool> hideLeaderboard;
         public static MelonPreferences_Entry<float> hueShift;
         internal static MelonPreferences_Entry<string> overrideURL;
 
@@ -95,7 +96,8 @@ namespace NeonLite.Modules
             setting = Settings.Add(Settings.h, "Medals", "comMedals", "Community Medals", "Shows new community medals past the developer red times to aim for.", true);
             hueShift = Settings.Add(Settings.h, "Medals", "hueShift", "Hue Shift", "Changes the hue of *all* medals (and related) help aid colorblind users in telling them apart.", 0f, new MelonLoader.Preferences.ValueRange<float>(0, 1));
             oldStyle = Settings.Add(Settings.h, "Medals", "oldStyle", "Stamp Style", "Display the community medals in the level info as it was pre-3.0.0.", false);
-            hideOld = Settings.Add(Settings.h, "Medals", "hideOld", "Hide Times", "Hides the time under the stamp while using the Stamp Style.", false);
+            hideOld = Settings.Add(Settings.h, "Medals", "hideOld", "Hide Times", "Hides unachieved medal times.", false);
+            hideLeaderboard = Settings.Add(Settings.h, "Medals", "hideLeaderboard", "Hide Leaderboard Medals", "Unachieved medals will appear the same as your own on the leaderboards.", false);
             overrideURL = Settings.Add(Settings.h, "Medals", "overrideURL", "Extension URL", "Specifies additional community medals JSON URL to apply on top of the existing community medals.", "");
 
             active = setting.SetupForModule(Activate, (_, after) => after);
@@ -464,6 +466,23 @@ namespace NeonLite.Modules
                 }
                 else
                     __instance.devStamp.SetActive(false);
+
+                if(hideOld.Value)
+                {
+                    String hiddenTime = "?:??.???";
+                    if(medalEarned < I(MedalEnum.Sapphire))
+                        __instance._aceMedalTime.text = (string)styleTime.Invoke(__instance, [
+                            hiddenTime,
+                            false]);
+                    if (medalEarned < I(MedalEnum.Amethyst))
+                        __instance._goldMedalTime.text = (string)styleTime.Invoke(__instance, [
+                            hiddenTime,
+                            false]);
+                    if (medalEarned < I(MedalEnum.Emerald))
+                        __instance._silverMedalTime.text = (string)styleTime.Invoke(__instance, [
+                            hiddenTime,
+                            false]);
+                }
             }
         }
 
@@ -525,6 +544,13 @@ namespace NeonLite.Modules
 
             int medalEarned = GetMedalIndex(levelData.levelID, newData._scoreValueMilliseconds * 1000);
             AdjustMaterial(__instance._medal);
+
+            if(hideLeaderboard.Value && medalEarned >= (int)MedalEnum.Dev)
+            {
+                int userMedal = GetMedalIndex(levelData.levelID); // medal the user has on this level
+                if (medalEarned > userMedal)
+                    medalEarned = Math.Max(userMedal, (int)MedalEnum.Ace); // ensure the medal to be displayed is only as high as the user's, but only as low as ace
+            }
 
             if (!levelData.isSidequest)
             {


### PR DESCRIPTION
Two things if you're interested!

Updated the 'Hide Times' setting so it works in normal style as well, replacing unachieved times with "?:??.???"
Added a 'Hide Leaderboard Medals' setting, so dev+ medals on the leaderboards display only as high as the user's (as low as ace), that way players can avoid getting spoiled by nearby players or their friends on the leaderboards if they want.

Feel free to ignore / close this pull request if these changes are at all unwanted or out of scope. 
Also feel free to close it and take any code from it if you want to do the implementation yourself, or in a different way. 

Here's a preview picture of what the changes look like with all possible ace+ medal permutations:
https://github.com/user-attachments/assets/72943b36-ea9d-465d-b81c-874bc241e7b5
It's a big picture so I didn't embed it (just open it in a new tab)
On the left is main level sapphire, amethyst, emerald, dev, ace (thank you Greenhouse...)
On the right is sidequest sapphire, amethyst, emerald, none (thank you Hellevator...)
You can see how both the unachieved times are nothing but question marks, and that the leaderboard only shows as high as the medal I already have. 
Spoiler free! 